### PR TITLE
feat(cdk): add BedrockChatbot- prefix to all stacks and resources for shared account visibility

### DIFF
--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -13,13 +13,13 @@ const env = { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_
 const stackPrefix = 'BedrockChatbot-'
 const resourcePrefix = 'BedrockChatbot-'
 
-const identity = new IdentityStack(app, `${stackPrefix}IdentityStack`, { 
+const identity = new IdentityStack(app, `${stackPrefix}IdentityStack`, {
   env,
   stackName: `${stackPrefix}IdentityStack`,
   resourcePrefix,
 })
 
-const data = new DataStack(app, `${stackPrefix}DataStack`, { 
+const data = new DataStack(app, `${stackPrefix}DataStack`, {
   env,
   stackName: `${stackPrefix}DataStack`,
   resourcePrefix,
@@ -35,7 +35,7 @@ new ApiStack(app, `${stackPrefix}ApiStack`, {
   policyTable: data.policyTable,
 })
 
-new FrontendStack(app, `${stackPrefix}FrontendStack`, { 
+new FrontendStack(app, `${stackPrefix}FrontendStack`, {
   env,
   stackName: `${stackPrefix}FrontendStack`,
   resourcePrefix,

--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -9,15 +9,34 @@ const app = new cdk.App()
 
 const env = { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION }
 
-const identity = new IdentityStack(app, 'IdentityStack', { env })
-const data = new DataStack(app, 'DataStack', { env })
+// Use prefix for shared AWS account visibility
+const stackPrefix = 'BedrockChatbot-'
+const resourcePrefix = 'BedrockChatbot-'
 
-new ApiStack(app, 'ApiStack', {
+const identity = new IdentityStack(app, `${stackPrefix}IdentityStack`, { 
   env,
+  stackName: `${stackPrefix}IdentityStack`,
+  resourcePrefix,
+})
+
+const data = new DataStack(app, `${stackPrefix}DataStack`, { 
+  env,
+  stackName: `${stackPrefix}DataStack`,
+  resourcePrefix,
+})
+
+new ApiStack(app, `${stackPrefix}ApiStack`, {
+  env,
+  stackName: `${stackPrefix}ApiStack`,
+  resourcePrefix,
   userPool: identity.userPool,
   userPoolClient: identity.userPoolClient,
   sessionTable: data.sessionTable,
   policyTable: data.policyTable,
 })
 
-new FrontendStack(app, 'FrontendStack', { env })
+new FrontendStack(app, `${stackPrefix}FrontendStack`, { 
+  env,
+  stackName: `${stackPrefix}FrontendStack`,
+  resourcePrefix,
+})

--- a/cdk/lib/api-stack.ts
+++ b/cdk/lib/api-stack.ts
@@ -16,6 +16,7 @@ import { join } from 'path'
 import { defaultConfig } from '../../lambda/config-schema.js'
 
 export interface ApiProps extends StackProps {
+  resourcePrefix: string
   sessionTable: Table
   policyTable: Table
   userPool: IUserPool
@@ -39,11 +40,13 @@ export class ApiStack extends Stack {
     })
 
     const q = new Queue(this, 'RequestsQ', {
+      queueName: `${props.resourcePrefix}RequestsQueue`,
       encryption: QueueEncryption.KMS_MANAGED,
       visibilityTimeout: Duration.minutes(5),
     })
 
     const onConnect = new NodejsFunction(this, 'WsOnConnect', {
+      functionName: `${props.resourcePrefix}WsOnConnect`,
       runtime: Runtime.NODEJS_20_X,
       entry: join(__dirname, '../../lambda/websocket/onconnect/index.js'),
       handler: 'handler',
@@ -52,6 +55,7 @@ export class ApiStack extends Stack {
       bundling: { minify: true, externalModules: [] },
     })
     const onDisconnect = new NodejsFunction(this, 'WsOnDisconnect', {
+      functionName: `${props.resourcePrefix}WsOnDisconnect`,
       runtime: Runtime.NODEJS_20_X,
       entry: join(__dirname, '../../lambda/websocket/ondisconnect/index.js'),
       handler: 'handler',
@@ -72,6 +76,7 @@ export class ApiStack extends Stack {
     )
 
     const defaultFn = new NodejsFunction(this, 'WsDefault', {
+      functionName: `${props.resourcePrefix}WsDefault`,
       runtime: Runtime.NODEJS_20_X,
       entry: join(__dirname, '../../lambda/websocket/default/index.js'),
       handler: 'handler',
@@ -100,6 +105,7 @@ export class ApiStack extends Stack {
     })
 
     const enqueueFn = new NodejsFunction(this, 'EnqueueFn', {
+      functionName: `${props.resourcePrefix}EnqueueFn`,
       runtime: Runtime.NODEJS_20_X,
       entry: join(__dirname, '../../lambda/enqueue/index.js'),
       handler: 'handler',
@@ -127,6 +133,7 @@ export class ApiStack extends Stack {
     })
 
     const workerFn = new NodejsFunction(this, 'WorkerFn', {
+      functionName: `${props.resourcePrefix}WorkerFn`,
       runtime: Runtime.NODEJS_20_X,
       entry: join(__dirname, '../../lambda/worker/index.js'),
       handler: 'handler',

--- a/cdk/lib/data-stack.ts
+++ b/cdk/lib/data-stack.ts
@@ -3,15 +3,20 @@ import { Construct } from 'constructs'
 import { Table, AttributeType, BillingMode } from 'aws-cdk-lib/aws-dynamodb'
 import { Bucket, BlockPublicAccess } from 'aws-cdk-lib/aws-s3'
 
+export interface DataProps extends StackProps {
+  resourcePrefix: string
+}
+
 export class DataStack extends Stack {
   public readonly sessionTable: Table
   public readonly policyTable: Table
   public readonly feedbackBucket: Bucket
 
-  constructor(scope: Construct, id: string, props?: StackProps) {
+  constructor(scope: Construct, id: string, props: DataProps) {
     super(scope, id, props)
 
     this.sessionTable = new Table(this, 'Sessions', {
+      tableName: `${props.resourcePrefix}Sessions`,
       partitionKey: { name: 'pk', type: AttributeType.STRING },
       sortKey: { name: 'sk', type: AttributeType.STRING },
       billingMode: BillingMode.PAY_PER_REQUEST,
@@ -20,12 +25,14 @@ export class DataStack extends Stack {
     })
 
     this.policyTable = new Table(this, 'Policies', {
+      tableName: `${props.resourcePrefix}Policies`,
       partitionKey: { name: 'userId', type: AttributeType.STRING },
       billingMode: BillingMode.PAY_PER_REQUEST,
       removalPolicy: RemovalPolicy.RETAIN,
     })
 
     this.feedbackBucket = new Bucket(this, 'FeedbackStore', {
+      bucketName: `${props.resourcePrefix.toLowerCase()}feedback-store-${this.account}`,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       enforceSSL: true,
     })

--- a/cdk/lib/frontend-stack.ts
+++ b/cdk/lib/frontend-stack.ts
@@ -10,8 +10,9 @@ import { S3Origin } from 'aws-cdk-lib/aws-cloudfront-origins'
 import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment'
 import { join } from 'path'
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface FrontendProps extends StackProps {}
+export interface FrontendProps extends StackProps {
+  resourcePrefix: string
+}
 
 export class FrontendStack extends Stack {
   public readonly siteUrl: string
@@ -20,6 +21,7 @@ export class FrontendStack extends Stack {
     super(scope, id, props)
 
     const bucket = new Bucket(this, 'SiteBucket', {
+      bucketName: `${props.resourcePrefix.toLowerCase()}site-${this.account}`,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       enforceSSL: true,
     })
@@ -34,10 +36,6 @@ export class FrontendStack extends Stack {
     })
 
     const sitePath = join(__dirname, '../../site')
-
-    // TODO: Use these endpoints to configure frontend
-    // const rest = Fn.importValue('BedrockChatbot-RestApiUrl')
-    // const ws = Fn.importValue('BedrockChatbot-WsEndpoint')
 
     new BucketDeployment(this, 'DeploySite', {
       destinationBucket: bucket,

--- a/cdk/lib/identity-stack.ts
+++ b/cdk/lib/identity-stack.ts
@@ -2,20 +2,26 @@ import { Stack, StackProps, Duration } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import { UserPool, UserPoolClient, AccountRecovery, OAuthScope } from 'aws-cdk-lib/aws-cognito'
 
+export interface IdentityProps extends StackProps {
+  resourcePrefix: string
+}
+
 export class IdentityStack extends Stack {
   public readonly userPool: UserPool
   public readonly userPoolClient: UserPoolClient
 
-  constructor(scope: Construct, id: string, props?: StackProps) {
+  constructor(scope: Construct, id: string, props: IdentityProps) {
     super(scope, id, props)
 
     this.userPool = new UserPool(this, 'UserPool', {
+      userPoolName: `${props.resourcePrefix}UserPool`,
       selfSignUpEnabled: false,
       signInAliases: { email: true },
       accountRecovery: AccountRecovery.EMAIL_ONLY,
     })
 
     this.userPoolClient = this.userPool.addClient('WebClient', {
+      userPoolClientName: `${props.resourcePrefix}WebClient`,
       authFlows: { userSrp: true },
       oAuth: { scopes: [OAuthScope.OPENID, OAuthScope.EMAIL, OAuthScope.PROFILE] },
       accessTokenValidity: Duration.hours(1),

--- a/package-lock.json
+++ b/package-lock.json
@@ -397,6 +397,58 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-cloudformation": {
+      "version": "3.902.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.902.0.tgz",
+      "integrity": "sha512-YqhLj8DQmvt66YJngoT5ZAEOEuQXJdtAxQXzbdJo3eaKqnwvER2v0WLDalxXZ/7tXj7lKsNPEf3K0ov/BOpRUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/credential-provider-node": "3.901.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.901.0",
+        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/middleware-retry": "^4.4.0",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.0",
+        "@smithy/util-defaults-mode-browser": "^4.2.0",
+        "@smithy/util-defaults-mode-node": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.902.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.902.0.tgz",
@@ -4896,6 +4948,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5210,6 +5277,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/detect-newline": {
@@ -6086,6 +6193,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6127,6 +6249,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -6171,6 +6311,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7229,6 +7384,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7768,6 +7941,18 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -8409,6 +8594,21 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8505,9 +8705,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@aws-sdk/client-cloudformation": "^3.0.0",
         "@aws-sdk/client-ssm": "^3.0.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
+        "open": "^10.0.0",
         "ora": "^8.0.0"
       },
       "bin": {

--- a/tools/cli/index.js
+++ b/tools/cli/index.js
@@ -14,6 +14,7 @@ import {
   handleRestore,
   handleReset,
 } from './lib/config.js'
+import { handleOpen } from './lib/ui.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -107,6 +108,14 @@ configCmd
   .description('Reset configuration to defaults')
   .action(async () => {
     await handleReset()
+  })
+
+// UI command
+program
+  .command('open')
+  .description('Open the chatbot UI in browser with latest config')
+  .action(async () => {
+    await handleOpen()
   })
 
 // Parse arguments

--- a/tools/cli/lib/ui.js
+++ b/tools/cli/lib/ui.js
@@ -1,0 +1,76 @@
+import { CloudFormationClient, DescribeStacksCommand } from '@aws-sdk/client-cloudformation'
+import ora from 'ora'
+import chalk from 'chalk'
+import open from 'open'
+
+const region = process.env.AWS_REGION || 'eu-central-1'
+
+/**
+ * Get stack outputs from CloudFormation
+ */
+async function getStackOutputs(stackName) {
+  const client = new CloudFormationClient({ region })
+  const command = new DescribeStacksCommand({ StackName: stackName })
+
+  try {
+    const response = await client.send(command)
+    const outputs = response.Stacks[0].Outputs || []
+    return outputs.reduce((acc, output) => {
+      acc[output.OutputKey] = output.OutputValue
+      return acc
+    }, {})
+  } catch (error) {
+    throw new Error(`Failed to get stack outputs: ${error.message}`)
+  }
+}
+
+/**
+ * Open the chatbot UI in browser with endpoints as URL parameters
+ */
+export async function handleOpen() {
+  const spinner = ora('Loading stack information...').start()
+
+  try {
+    // Get API stack outputs
+    const apiOutputs = await getStackOutputs('ApiStack')
+    const restApiUrl = apiOutputs.RestApiUrl
+    const wsEndpoint = apiOutputs.WsEndpoint
+
+    if (!restApiUrl || !wsEndpoint) {
+      spinner.fail('Missing API endpoints in ApiStack outputs')
+      console.log(chalk.yellow('\nMake sure the ApiStack is deployed with outputs:'))
+      console.log('  - RestApiUrl')
+      console.log('  - WsEndpoint')
+      process.exit(1)
+    }
+
+    // Get frontend stack outputs
+    spinner.text = 'Getting frontend URL...'
+    const frontendOutputs = await getStackOutputs('FrontendStack')
+    const siteUrl = frontendOutputs.SiteUrl
+
+    if (!siteUrl) {
+      spinner.fail('Missing SiteUrl in FrontendStack outputs')
+      process.exit(1)
+    }
+
+    // Construct URL with query parameters
+    const url = new URL(siteUrl)
+    url.searchParams.set('rest', `${restApiUrl}/chat`)
+    url.searchParams.set('ws', wsEndpoint)
+
+    spinner.succeed('Configuration loaded')
+
+    console.log(chalk.green('\n✓ Opening chatbot UI...'))
+    console.log(chalk.dim(`  URL: ${siteUrl}`))
+    console.log(chalk.dim(`  REST: ${restApiUrl}/chat`))
+    console.log(chalk.dim(`  WebSocket: ${wsEndpoint}`))
+
+    // Open browser with parameters
+    await open(url.toString())
+  } catch (error) {
+    spinner.fail(`Failed to open UI: ${error.message}`)
+    console.error(chalk.red('\nError details:'), error)
+    process.exit(1)
+  }
+}

--- a/tools/cli/lib/ui.js
+++ b/tools/cli/lib/ui.js
@@ -32,13 +32,13 @@ export async function handleOpen() {
 
   try {
     // Get API stack outputs
-    const apiOutputs = await getStackOutputs('ApiStack')
+    const apiOutputs = await getStackOutputs('BedrockChatbot-ApiStack')
     const restApiUrl = apiOutputs.RestApiUrl
     const wsEndpoint = apiOutputs.WsEndpoint
 
     if (!restApiUrl || !wsEndpoint) {
-      spinner.fail('Missing API endpoints in ApiStack outputs')
-      console.log(chalk.yellow('\nMake sure the ApiStack is deployed with outputs:'))
+      spinner.fail('Missing API endpoints in BedrockChatbot-ApiStack outputs')
+      console.log(chalk.yellow('\nMake sure the BedrockChatbot-ApiStack is deployed with outputs:'))
       console.log('  - RestApiUrl')
       console.log('  - WsEndpoint')
       process.exit(1)
@@ -46,11 +46,11 @@ export async function handleOpen() {
 
     // Get frontend stack outputs
     spinner.text = 'Getting frontend URL...'
-    const frontendOutputs = await getStackOutputs('FrontendStack')
+    const frontendOutputs = await getStackOutputs('BedrockChatbot-FrontendStack')
     const siteUrl = frontendOutputs.SiteUrl
 
     if (!siteUrl) {
-      spinner.fail('Missing SiteUrl in FrontendStack outputs')
+      spinner.fail('Missing SiteUrl in BedrockChatbot-FrontendStack outputs')
       process.exit(1)
     }
 

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -21,9 +21,11 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@aws-sdk/client-cloudformation": "^3.0.0",
     "@aws-sdk/client-ssm": "^3.0.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
+    "open": "^10.0.0",
     "ora": "^8.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds `BedrockChatbot-` prefix to all CloudFormation stacks and AWS resources to ensure clear identification in the shared AWS account.

## Problem

When deploying to a shared AWS account with multiple projects (CobainSandbox*, WebhookGatekeeper*, etc.), our generic stack names (IdentityStack, DataStack, ApiStack, FrontendStack) and resource names made it difficult to identify which resources belong to the bedrock-chatbot project.

## Solution

### Stack Names
- `IdentityStack` → `BedrockChatbot-IdentityStack`
- `DataStack` → `BedrockChatbot-DataStack`
- `ApiStack` → `BedrockChatbot-ApiStack`
- `FrontendStack` → `BedrockChatbot-FrontendStack`

### Resource Names
All AWS resources now include the `BedrockChatbot-` prefix:

**Lambda Functions:**
- `BedrockChatbot-WsOnConnect`
- `BedrockChatbot-WsOnDisconnect`
- `BedrockChatbot-WsDefault`
- `BedrockChatbot-EnqueueFn`
- `BedrockChatbot-WorkerFn`

**DynamoDB Tables:**
- `BedrockChatbot-Sessions`
- `BedrockChatbot-Policies`

**S3 Buckets:**
- `bedrockchatbot-feedback-store-{account}`
- `bedrockchatbot-site-{account}`

**SQS Queue:**
- `BedrockChatbot-RequestsQueue`

**Cognito:**
- `BedrockChatbot-UserPool`
- `BedrockChatbot-WebClient`

## Changes

- **cdk/bin/app.ts**: Added `stackPrefix` and `resourcePrefix` constants, pass to all stack constructors
- **cdk/lib/identity-stack.ts**: Added `resourcePrefix` to UserPool and UserPoolClient names
- **cdk/lib/data-stack.ts**: Added `resourcePrefix` to DynamoDB tables and S3 bucket names
- **cdk/lib/api-stack.ts**: Added `resourcePrefix` to all Lambda functions and SQS queue
- **cdk/lib/frontend-stack.ts**: Added `resourcePrefix` to S3 bucket, removed outdated TODOs
- **tools/cli/lib/ui.js**: Updated stack name references to use new prefixed names

## Testing

- [ ] Deploy to sandbox account
- [ ] Verify all resources are clearly identifiable in AWS Console
- [ ] Test CLI `open` command with new stack names
- [ ] Verify config management still works

## Notes

This follows the naming pattern already established by other projects in the shared account (CobainSandbox*, WebhookGatekeeper*) for consistency and easy resource identification.