### PR TITLE
feat: Model-agnostic inference via AWS Bedrock Converse API

### DIFF
--- a/cdk/lib/api-stack.ts
+++ b/cdk/lib/api-stack.ts
@@ -161,8 +161,13 @@ export class ApiStack extends Stack {
       new PolicyStatement({
         effect: Effect.ALLOW,
         actions: [
+          // Model-agnostic Converse API (preferred)
+          'bedrock:Converse',
+          'bedrock:ConverseStream',
+          // Legacy InvokeModel APIs (for backwards compatibility)
           'bedrock:InvokeModel',
           'bedrock:InvokeModelWithResponseStream',
+          // Knowledge Base retrieval
           'bedrock:Retrieve',
           'bedrock:RetrieveAndGenerate',
           'bedrock:RetrieveAndGenerateStream',

--- a/config.example.json
+++ b/config.example.json
@@ -1,7 +1,6 @@
 {
   "model": {
-    "modelId": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "anthropicVersion": "bedrock-2023-05-31"
+    "modelId": "anthropic.claude-3-5-sonnet-20240620-v1:0"
   },
   "knowledgeBase": {
     "enabled": false,
@@ -19,7 +18,7 @@
   "generation": {
     "maxTokens": 800,
     "temperature": 0.2,
-    "topP": 0.9,
-    "topK": 250
-  }
+    "topP": 0.9
+  },
+  "modelSpecific": {}
 }

--- a/lambda/config-schema.js
+++ b/lambda/config-schema.js
@@ -1,6 +1,7 @@
 /**
  * Configuration schema for Bedrock Chatbot
  * This defines the structure of the configuration stored in SSM Parameter Store
+ * Uses the Converse API for model-agnostic inference across all Bedrock models
  */
 
 /**
@@ -10,12 +11,12 @@
  * @property {PromptConfig} prompts - System prompts configuration
  * @property {RetrievalConfig} retrieval - Knowledge base retrieval configuration
  * @property {GenerationConfig} generation - Generation parameters
+ * @property {Object} modelSpecific - Optional model-specific parameters (passed as additionalModelRequestFields)
  */
 
 /**
  * @typedef {Object} ModelConfig
- * @property {string} modelId - Bedrock model ID (e.g., anthropic.claude-3-5-sonnet-20240620-v1:0)
- * @property {string} anthropicVersion - Anthropic API version
+ * @property {string} modelId - Bedrock model ID (e.g., anthropic.claude-3-5-sonnet-20240620-v1:0, amazon.titan-text-express-v1, meta.llama3-70b-instruct-v1:0)
  */
 
 /**
@@ -42,7 +43,6 @@
  * @property {number} maxTokens - Maximum tokens to generate
  * @property {number} temperature - Temperature for generation (0.0 to 1.0)
  * @property {number} topP - Top P sampling parameter
- * @property {number} topK - Top K sampling parameter
  */
 
 /**
@@ -52,7 +52,6 @@
 const defaultConfig = {
   model: {
     modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
-    anthropicVersion: 'bedrock-2023-05-31',
   },
   knowledgeBase: {
     enabled: false,
@@ -72,8 +71,8 @@ const defaultConfig = {
     maxTokens: 800,
     temperature: 0.2,
     topP: 0.9,
-    topK: 250,
   },
+  modelSpecific: {},
 }
 
 module.exports = {

--- a/lambda/worker/__tests__/handler.test.js
+++ b/lambda/worker/__tests__/handler.test.js
@@ -1,0 +1,447 @@
+/**
+ * Worker Lambda Handler Tests
+ * Tests for model-agnostic ConverseStream API integration
+ */
+
+import { jest } from '@jest/globals'
+
+// Mock environment variables
+process.env.WS_API_ENDPOINT = 'https://test.execute-api.us-east-1.amazonaws.com'
+process.env.CONFIG_PARAM_NAME = '/bedrock-chatbot/config'
+
+// Create mock implementations
+const mockPostToConnection = jest.fn().mockResolvedValue({})
+const mockConverseStreamSend = jest.fn()
+const mockConverseSend = jest.fn()
+const mockRetrieveSend = jest.fn()
+const mockSSMSend = jest.fn()
+
+// Mock AWS SDK modules
+jest.unstable_mockModule('@aws-sdk/client-apigatewaymanagementapi', () => ({
+  ApiGatewayManagementApiClient: jest.fn(() => ({
+    send: mockPostToConnection,
+  })),
+  PostToConnectionCommand: jest.fn((params) => ({ ...params, _type: 'PostToConnection' })),
+}))
+
+jest.unstable_mockModule('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntimeClient: jest.fn(() => ({
+    send: jest.fn((cmd) => {
+      if (cmd._type === 'ConverseStream') {
+        return mockConverseStreamSend(cmd)
+      }
+      if (cmd._type === 'Converse') {
+        return mockConverseSend(cmd)
+      }
+      throw new Error('Unknown command')
+    }),
+  })),
+  ConverseStreamCommand: jest.fn((params) => ({ ...params, _type: 'ConverseStream' })),
+  ConverseCommand: jest.fn((params) => ({ ...params, _type: 'Converse' })),
+}))
+
+jest.unstable_mockModule('@aws-sdk/client-bedrock-agent-runtime', () => ({
+  BedrockAgentRuntimeClient: jest.fn(() => ({
+    send: mockRetrieveSend,
+  })),
+  RetrieveCommand: jest.fn((params) => params),
+}))
+
+jest.unstable_mockModule('@aws-sdk/client-ssm', () => ({
+  SSMClient: jest.fn(() => ({
+    send: mockSSMSend,
+  })),
+  GetParameterCommand: jest.fn((params) => params),
+}))
+
+// Helper to create async iterable stream for ConverseStream responses
+function createMockStream(events) {
+  return {
+    [Symbol.asyncIterator]: async function* () {
+      for (const event of events) {
+        yield event
+      }
+    },
+  }
+}
+
+describe('Worker Lambda Handler', () => {
+  let handler
+
+  const defaultConfig = {
+    model: {
+      modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+    },
+    knowledgeBase: {
+      enabled: false,
+      knowledgeBaseId: '',
+    },
+    prompts: {
+      systemWithContext: 'You are helpful with context.',
+      systemWithoutContext: 'You are helpful.',
+      contextTemplate: 'CONTEXT:\n{context}\n\nUSER: {prompt}',
+    },
+    retrieval: {
+      numberOfResults: 6,
+      maxContextLength: 1000,
+    },
+    generation: {
+      maxTokens: 800,
+      temperature: 0.5,
+      topP: 0.9,
+    },
+    modelSpecific: {},
+  }
+
+  const createSQSEvent = (prompt, connectionId = 'test-connection-id') => ({
+    Records: [
+      {
+        body: JSON.stringify({ prompt, connectionId }),
+      },
+    ],
+  })
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+
+    // Mock SSM to return default config
+    mockSSMSend.mockResolvedValue({
+      Parameter: {
+        Value: JSON.stringify(defaultConfig),
+      },
+    })
+
+    // Re-import handler to reset module state (config cache)
+    const module = await import('../index.js')
+    handler = module.handler
+  })
+
+  describe('ConverseStream API Integration', () => {
+    test('constructs correct ConverseStream parameters for Claude model', async () => {
+      const streamEvents = [
+        { contentBlockDelta: { delta: { text: 'Hello' } } },
+        { contentBlockDelta: { delta: { text: ' world' } } },
+        { messageStop: { stopReason: 'end_turn' } },
+      ]
+
+      mockConverseStreamSend.mockResolvedValue({
+        stream: createMockStream(streamEvents),
+      })
+
+      await handler(createSQSEvent('Test prompt'))
+
+      // Verify ConverseStreamCommand was called with correct structure
+      const { ConverseStreamCommand } = await import('@aws-sdk/client-bedrock-runtime')
+      expect(ConverseStreamCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              role: 'user',
+              content: expect.arrayContaining([expect.objectContaining({ text: expect.any(String) })]),
+            }),
+          ]),
+          system: expect.arrayContaining([expect.objectContaining({ text: expect.any(String) })]),
+          inferenceConfig: expect.objectContaining({
+            maxTokens: 800,
+            temperature: 0.5,
+            topP: 0.9,
+          }),
+        }),
+      )
+    })
+
+    test('streams text deltas to WebSocket connection', async () => {
+      const streamEvents = [
+        { contentBlockDelta: { delta: { text: 'Hello' } } },
+        { contentBlockDelta: { delta: { text: ' world' } } },
+        { messageStop: { stopReason: 'end_turn' } },
+      ]
+
+      mockConverseStreamSend.mockResolvedValue({
+        stream: createMockStream(streamEvents),
+      })
+
+      await handler(createSQSEvent('Test prompt'))
+
+      // Verify deltas were sent
+      const postCalls = mockPostToConnection.mock.calls
+      expect(postCalls.length).toBeGreaterThanOrEqual(3) // At least 2 deltas + complete
+
+      // Check delta events
+      const deltaMessages = postCalls
+        .map((call) => JSON.parse(Buffer.from(call[0].Data).toString()))
+        .filter((msg) => msg.event === 'delta')
+
+      expect(deltaMessages).toHaveLength(2)
+      expect(deltaMessages[0].content).toBe('Hello')
+      expect(deltaMessages[1].content).toBe(' world')
+
+      // Check complete event
+      const completeMessage = postCalls
+        .map((call) => JSON.parse(Buffer.from(call[0].Data).toString()))
+        .find((msg) => msg.event === 'complete')
+
+      expect(completeMessage).toBeDefined()
+    })
+
+    test('handles stream errors gracefully', async () => {
+      const streamEvents = [
+        { contentBlockDelta: { delta: { text: 'Partial' } } },
+        { modelStreamErrorException: { message: 'Model error' } },
+      ]
+
+      mockConverseStreamSend.mockResolvedValue({
+        stream: createMockStream(streamEvents),
+      })
+
+      await expect(handler(createSQSEvent('Test prompt'))).rejects.toThrow('Model error')
+    })
+  })
+
+  describe('Model-Specific Configuration', () => {
+    test('includes additionalModelRequestFields when modelSpecific is set', async () => {
+      const configWithModelSpecific = {
+        ...defaultConfig,
+        modelSpecific: {
+          top_k: 250,
+          custom_param: 'value',
+        },
+      }
+
+      mockSSMSend.mockResolvedValue({
+        Parameter: {
+          Value: JSON.stringify(configWithModelSpecific),
+        },
+      })
+
+      const streamEvents = [
+        { contentBlockDelta: { delta: { text: 'Response' } } },
+        { messageStop: { stopReason: 'end_turn' } },
+      ]
+
+      mockConverseStreamSend.mockResolvedValue({
+        stream: createMockStream(streamEvents),
+      })
+
+      // Re-import to clear config cache
+      const module = await import('../index.js')
+      await module.handler(createSQSEvent('Test'))
+
+      const { ConverseStreamCommand } = await import('@aws-sdk/client-bedrock-runtime')
+      expect(ConverseStreamCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          additionalModelRequestFields: {
+            top_k: 250,
+            custom_param: 'value',
+          },
+        }),
+      )
+    })
+
+    test('works with Amazon Titan model configuration', async () => {
+      const titanConfig = {
+        ...defaultConfig,
+        model: { modelId: 'amazon.titan-text-express-v1' },
+      }
+
+      mockSSMSend.mockResolvedValue({
+        Parameter: {
+          Value: JSON.stringify(titanConfig),
+        },
+      })
+
+      const streamEvents = [
+        { contentBlockDelta: { delta: { text: 'Titan response' } } },
+        { messageStop: { stopReason: 'end_turn' } },
+      ]
+
+      mockConverseStreamSend.mockResolvedValue({
+        stream: createMockStream(streamEvents),
+      })
+
+      const module = await import('../index.js')
+      await module.handler(createSQSEvent('Test'))
+
+      const { ConverseStreamCommand } = await import('@aws-sdk/client-bedrock-runtime')
+      expect(ConverseStreamCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelId: 'amazon.titan-text-express-v1',
+        }),
+      )
+    })
+
+    test('works with Meta Llama model configuration', async () => {
+      const llamaConfig = {
+        ...defaultConfig,
+        model: { modelId: 'meta.llama3-70b-instruct-v1:0' },
+      }
+
+      mockSSMSend.mockResolvedValue({
+        Parameter: {
+          Value: JSON.stringify(llamaConfig),
+        },
+      })
+
+      const streamEvents = [
+        { contentBlockDelta: { delta: { text: 'Llama response' } } },
+        { messageStop: { stopReason: 'end_turn' } },
+      ]
+
+      mockConverseStreamSend.mockResolvedValue({
+        stream: createMockStream(streamEvents),
+      })
+
+      const module = await import('../index.js')
+      await module.handler(createSQSEvent('Test'))
+
+      const { ConverseStreamCommand } = await import('@aws-sdk/client-bedrock-runtime')
+      expect(ConverseStreamCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelId: 'meta.llama3-70b-instruct-v1:0',
+        }),
+      )
+    })
+  })
+
+  describe('Knowledge Base Integration', () => {
+    test('retrieves context when Knowledge Base is enabled', async () => {
+      const kbConfig = {
+        ...defaultConfig,
+        knowledgeBase: {
+          enabled: true,
+          knowledgeBaseId: 'test-kb-id',
+        },
+      }
+
+      mockSSMSend.mockResolvedValue({
+        Parameter: {
+          Value: JSON.stringify(kbConfig),
+        },
+      })
+
+      mockRetrieveSend.mockResolvedValue({
+        retrievalResults: [
+          { content: { text: 'Retrieved context 1' } },
+          { content: { text: 'Retrieved context 2' } },
+        ],
+      })
+
+      const streamEvents = [
+        { contentBlockDelta: { delta: { text: 'Response with context' } } },
+        { messageStop: { stopReason: 'end_turn' } },
+      ]
+
+      mockConverseStreamSend.mockResolvedValue({
+        stream: createMockStream(streamEvents),
+      })
+
+      const module = await import('../index.js')
+      await module.handler(createSQSEvent('Test query'))
+
+      // Verify KB retrieval was called
+      expect(mockRetrieveSend).toHaveBeenCalled()
+    })
+
+    test('uses systemWithContext prompt when KB retrieval succeeds', async () => {
+      const kbConfig = {
+        ...defaultConfig,
+        knowledgeBase: {
+          enabled: true,
+          knowledgeBaseId: 'test-kb-id',
+        },
+      }
+
+      mockSSMSend.mockResolvedValue({
+        Parameter: {
+          Value: JSON.stringify(kbConfig),
+        },
+      })
+
+      mockRetrieveSend.mockResolvedValue({
+        retrievalResults: [{ content: { text: 'Context' } }],
+      })
+
+      const streamEvents = [
+        { contentBlockDelta: { delta: { text: 'Response' } } },
+        { messageStop: { stopReason: 'end_turn' } },
+      ]
+
+      mockConverseStreamSend.mockResolvedValue({
+        stream: createMockStream(streamEvents),
+      })
+
+      const module = await import('../index.js')
+      await module.handler(createSQSEvent('Test'))
+
+      const { ConverseStreamCommand } = await import('@aws-sdk/client-bedrock-runtime')
+      expect(ConverseStreamCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          system: expect.arrayContaining([
+            expect.objectContaining({
+              text: 'You are helpful with context.',
+            }),
+          ]),
+        }),
+      )
+    })
+  })
+
+  describe('Mock Mode', () => {
+    test('streams mock response when KB ID is MOCK', async () => {
+      const mockConfig = {
+        ...defaultConfig,
+        knowledgeBase: {
+          enabled: true,
+          knowledgeBaseId: 'MOCK',
+        },
+      }
+
+      mockSSMSend.mockResolvedValue({
+        Parameter: {
+          Value: JSON.stringify(mockConfig),
+        },
+      })
+
+      const module = await import('../index.js')
+      await module.handler(createSQSEvent('Test'))
+
+      // Should NOT call Bedrock in mock mode
+      expect(mockConverseStreamSend).not.toHaveBeenCalled()
+
+      // Should send mock response via WebSocket
+      expect(mockPostToConnection).toHaveBeenCalled()
+
+      // Verify complete event was sent
+      const completeMessage = mockPostToConnection.mock.calls
+        .map((call) => JSON.parse(Buffer.from(call[0].Data).toString()))
+        .find((msg) => msg.event === 'complete')
+
+      expect(completeMessage).toBeDefined()
+    })
+  })
+
+  describe('Inference Profile Fallback', () => {
+    test('uses ConverseCommand when inference profile ARN is set', async () => {
+      process.env.INFERENCE_PROFILE_ARN = 'arn:aws:bedrock:us-east-1:123456789:inference-profile/test'
+
+      mockConverseSend.mockResolvedValue({
+        output: {
+          message: {
+            content: [{ text: 'Non-streaming response' }],
+          },
+        },
+      })
+
+      const module = await import('../index.js')
+      await module.handler(createSQSEvent('Test'))
+
+      // Verify ConverseCommand (non-streaming) was called
+      const { ConverseCommand } = await import('@aws-sdk/client-bedrock-runtime')
+      expect(ConverseCommand).toHaveBeenCalled()
+
+      // Clean up
+      delete process.env.INFERENCE_PROFILE_ARN
+    })
+  })
+})

--- a/lambda/worker/index.js
+++ b/lambda/worker/index.js
@@ -4,12 +4,9 @@ const {
 } = require('@aws-sdk/client-apigatewaymanagementapi')
 const {
   BedrockRuntimeClient,
-  InvokeModelWithResponseStreamCommand,
+  ConverseStreamCommand,
+  ConverseCommand,
 } = require('@aws-sdk/client-bedrock-runtime')
-const { SignatureV4 } = require('@aws-sdk/signature-v4')
-const { Sha256 } = require('@aws-crypto/sha256-js')
-const { HttpRequest } = require('@aws-sdk/protocol-http')
-const { defaultProvider } = require('@aws-sdk/credential-provider-node')
 const {
   BedrockAgentRuntimeClient,
   RetrieveCommand,
@@ -137,48 +134,54 @@ exports.handler = async (event) => {
       ? config.prompts.contextTemplate.replace('{context}', ctx).replace('{prompt}', prompt)
       : prompt
 
-    const body = {
-      anthropic_version: config.model.anthropicVersion,
-      max_tokens: config.generation.maxTokens,
-      temperature: config.generation.temperature,
-      top_p: config.generation.topP,
-      top_k: config.generation.topK,
-      messages: [{ role: 'user', content: `${system}\n\n${user}` }],
+    // Build Converse API parameters (model-agnostic format)
+    const converseParams = {
+      modelId: config.model.modelId,
+      messages: [{ role: 'user', content: [{ text: user }] }],
+      system: [{ text: system }],
+      inferenceConfig: {
+        maxTokens: config.generation.maxTokens,
+        temperature: config.generation.temperature,
+        topP: config.generation.topP,
+      },
     }
 
-    const base = {
-      contentType: 'application/json',
-      accept: 'application/json',
-      body: JSON.stringify(body),
+    // Add model-specific parameters if configured
+    if (config.modelSpecific && Object.keys(config.modelSpecific).length > 0) {
+      converseParams.additionalModelRequestFields = config.modelSpecific
     }
+
     const useProfile = process.env.INFERENCE_PROFILE_ARN && process.env.INFERENCE_PROFILE_ARN.trim()
 
     if (!useProfile) {
-      // Regular streaming with modelId
-      const cmd = new InvokeModelWithResponseStreamCommand({
-        ...base,
-        modelId: config.model.modelId,
-      })
+      // Streaming with ConverseStream API (model-agnostic)
+      const cmd = new ConverseStreamCommand(converseParams)
       const resp = await bedrock.send(cmd)
       let seq = 0
-      for await (const evt of resp.body) {
-        if (evt.chunk && evt.chunk.bytes) {
-          try {
-            const payload = JSON.parse(Buffer.from(evt.chunk.bytes).toString('utf-8'))
-            const delta = payload.delta?.text || payload.output_text || ''
-            if (delta) {
-              await ws.send(
-                new PostToConnectionCommand({
-                  ConnectionId: connectionId,
-                  Data: Buffer.from(JSON.stringify({ event: 'delta', seq: seq++, content: delta })),
-                }),
-              )
-            }
-          } catch (e) {
-            console.log('stream parse error', e)
-          }
+
+      for await (const evt of resp.stream) {
+        // Handle content block delta events (streaming text)
+        if (evt.contentBlockDelta?.delta?.text) {
+          const delta = evt.contentBlockDelta.delta.text
+          await ws.send(
+            new PostToConnectionCommand({
+              ConnectionId: connectionId,
+              Data: Buffer.from(JSON.stringify({ event: 'delta', seq: seq++, content: delta })),
+            }),
+          )
+        }
+        // Handle message stop event (end of response)
+        if (evt.messageStop) {
+          break
+        }
+        // Handle errors in stream
+        if (evt.internalServerException || evt.modelStreamErrorException) {
+          const error = evt.internalServerException || evt.modelStreamErrorException
+          console.log('Stream error:', error.message)
+          throw new Error(error.message || 'Stream error')
         }
       }
+
       await ws.send(
         new PostToConnectionCommand({
           ConnectionId: connectionId,
@@ -186,50 +189,26 @@ exports.handler = async (event) => {
         }),
       )
     } else {
-      // Fallback: non-streaming invoke via inference profile, then stream chunks to client
-      const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'eu-central-1'
-      const endpoint = `https://bedrock-runtime.${region}.amazonaws.com`
-      const path = `/inference-profiles/${encodeURIComponent(process.env.INFERENCE_PROFILE_ARN)}/invoke-model`
-
-      const request = new HttpRequest({
-        protocol: 'https:',
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          accept: 'application/json',
-        },
-        hostname: `bedrock-runtime.${region}.amazonaws.com`,
-        path,
-        body: JSON.stringify(body),
-      })
-
-      const signer = new SignatureV4({
-        service: 'bedrock',
-        region,
-        sha256: Sha256,
-        credentials: defaultProvider(),
-      })
-      const signed = await signer.sign(request)
-
-      const res = await fetch(`${endpoint}${path}`, {
-        method: 'POST',
-        headers: signed.headers,
-        body: request.body,
-      })
-      if (!res.ok) {
-        const errText = await res.text().catch(() => '')
-        console.log('profile invoke error', res.status, errText)
-        throw new Error(`Bedrock profile invoke failed: ${res.status}`)
+      // Fallback: non-streaming Converse API for inference profiles
+      // Use the inference profile ARN as the modelId
+      const profileParams = {
+        ...converseParams,
+        modelId: process.env.INFERENCE_PROFILE_ARN,
       }
-      const txt = await res.text()
-      let json
-      try {
-        json = JSON.parse(txt)
-      } catch {
-        json = {}
+
+      const resp = await bedrock.send(new ConverseCommand(profileParams))
+
+      // Extract text from the response
+      let out = ''
+      if (resp.output?.message?.content) {
+        for (const block of resp.output.message.content) {
+          if (block.text) {
+            out += block.text
+          }
+        }
       }
-      const out = json.output_text || json.completion || JSON.stringify(json)
-      // stream the output in small chunks
+
+      // Stream the output in small chunks to client
       let seq = 0
       for (const ch of out.split('')) {
         await ws.send(

--- a/tools/cli/__tests__/config.test.js
+++ b/tools/cli/__tests__/config.test.js
@@ -50,7 +50,6 @@ describe('Config Module', () => {
       const validConfig = {
         model: {
           modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
-          anthropicVersion: 'bedrock-2023-05-31',
         },
         knowledgeBase: {
           enabled: false,
@@ -69,8 +68,8 @@ describe('Config Module', () => {
           maxTokens: 800,
           temperature: 0.2,
           topP: 0.9,
-          topK: 250,
         },
+        modelSpecific: {},
       }
 
       const errors = validateConfig(validConfig)
@@ -79,9 +78,7 @@ describe('Config Module', () => {
 
     test('detects missing model.modelId', () => {
       const invalidConfig = {
-        model: {
-          anthropicVersion: 'bedrock-2023-05-31',
-        },
+        model: {},
         knowledgeBase: {
           enabled: false,
           knowledgeBaseId: '',
@@ -99,7 +96,6 @@ describe('Config Module', () => {
           maxTokens: 800,
           temperature: 0.2,
           topP: 0.9,
-          topK: 250,
         },
       }
 
@@ -111,8 +107,11 @@ describe('Config Module', () => {
     test('detects wrong type for generation.temperature', () => {
       const invalidConfig = {
         model: {
-          modelId: 'test',
-          anthropicVersion: 'bedrock-2023-05-31',
+          modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+        },
+        knowledgeBase: {
+          enabled: false,
+          knowledgeBaseId: '',
         },
         prompts: {
           systemWithContext: 'test',
@@ -127,7 +126,6 @@ describe('Config Module', () => {
           maxTokens: 800,
           temperature: 'high', // Should be number
           topP: 0.9,
-          topK: 250,
         },
       }
 
@@ -139,8 +137,11 @@ describe('Config Module', () => {
     test('detects missing prompts section', () => {
       const invalidConfig = {
         model: {
-          modelId: 'test',
-          anthropicVersion: 'bedrock-2023-05-31',
+          modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+        },
+        knowledgeBase: {
+          enabled: false,
+          knowledgeBaseId: '',
         },
         retrieval: {
           numberOfResults: 6,
@@ -150,7 +151,6 @@ describe('Config Module', () => {
           maxTokens: 800,
           temperature: 0.2,
           topP: 0.9,
-          topK: 250,
         },
       }
 
@@ -163,7 +163,6 @@ describe('Config Module', () => {
       const invalidConfig = {
         model: {
           // missing modelId
-          anthropicVersion: 'bedrock-2023-05-31',
         },
         prompts: {
           systemWithContext: 'test',
@@ -178,7 +177,6 @@ describe('Config Module', () => {
           maxTokens: 800,
           temperature: 0.2,
           topP: 0.9,
-          topK: 250,
         },
       }
 
@@ -189,8 +187,7 @@ describe('Config Module', () => {
     test('validates all generation parameters', () => {
       const validConfig = {
         model: {
-          modelId: 'test',
-          anthropicVersion: 'bedrock-2023-05-31',
+          modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
         },
         knowledgeBase: {
           enabled: true,
@@ -209,7 +206,6 @@ describe('Config Module', () => {
           maxTokens: 1500,
           temperature: 0.7,
           topP: 0.95,
-          topK: 300,
         },
       }
 
@@ -220,8 +216,7 @@ describe('Config Module', () => {
     test('validates retrieval parameters', () => {
       const validConfig = {
         model: {
-          modelId: 'test',
-          anthropicVersion: 'bedrock-2023-05-31',
+          modelId: 'amazon.titan-text-express-v1',
         },
         knowledgeBase: {
           enabled: false,
@@ -240,7 +235,6 @@ describe('Config Module', () => {
           maxTokens: 800,
           temperature: 0.2,
           topP: 0.9,
-          topK: 250,
         },
       }
 
@@ -251,15 +245,14 @@ describe('Config Module', () => {
     test('handles empty config object', () => {
       const errors = validateConfig({})
       expect(errors.length).toBeGreaterThan(0)
-      // Should report all missing required fields
-      expect(errors.length).toBeGreaterThanOrEqual(12)
+      // Should report all missing required fields (11 fields now)
+      expect(errors.length).toBeGreaterThanOrEqual(11)
     })
 
     test('handles null values', () => {
       const invalidConfig = {
         model: {
           modelId: null,
-          anthropicVersion: null,
         },
         knowledgeBase: {
           enabled: null,
@@ -278,7 +271,6 @@ describe('Config Module', () => {
           maxTokens: null,
           temperature: null,
           topP: null,
-          topK: null,
         },
       }
 
@@ -303,8 +295,7 @@ describe('Config Module', () => {
       test('fetches configuration from SSM successfully', async () => {
         const mockConfig = {
           model: {
-            modelId: 'test-model',
-            anthropicVersion: 'bedrock-2023-05-31',
+            modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
           },
           knowledgeBase: {
             enabled: false,
@@ -323,8 +314,8 @@ describe('Config Module', () => {
             maxTokens: 800,
             temperature: 0.2,
             topP: 0.9,
-            topK: 250,
           },
+          modelSpecific: {},
         }
 
         mockSend.mockResolvedValueOnce({
@@ -364,7 +355,7 @@ describe('Config Module', () => {
     describe('updateConfig', () => {
       test('updates configuration successfully with object', async () => {
         const newConfig = {
-          model: { modelId: 'new-model', anthropicVersion: 'v1' },
+          model: { modelId: 'anthropic.claude-3-haiku-20240307-v1:0' },
           knowledgeBase: { enabled: true, knowledgeBaseId: 'my-kb' },
           prompts: {
             systemWithContext: 'new',
@@ -372,7 +363,8 @@ describe('Config Module', () => {
             contextTemplate: 'new',
           },
           retrieval: { numberOfResults: 10, maxContextLength: 2000 },
-          generation: { maxTokens: 1000, temperature: 0.5, topP: 0.95, topK: 300 },
+          generation: { maxTokens: 1000, temperature: 0.5, topP: 0.95 },
+          modelSpecific: {},
         }
 
         mockSend.mockResolvedValueOnce({})

--- a/tools/cli/__tests__/model-validation.test.js
+++ b/tools/cli/__tests__/model-validation.test.js
@@ -1,0 +1,305 @@
+import { jest } from '@jest/globals'
+
+// Create mocks before any imports
+const mockOra = jest.fn(() => ({
+  start: jest.fn().mockReturnThis(),
+  succeed: jest.fn().mockReturnThis(),
+  fail: jest.fn().mockReturnThis(),
+  stop: jest.fn().mockReturnThis(),
+}))
+
+const mockChalk = new Proxy(
+  {},
+  {
+    get: () => (str) => str,
+  },
+)
+
+// Mock modules BEFORE importing anything else
+jest.unstable_mockModule('@aws-sdk/client-ssm', () => ({
+  SSMClient: jest.fn(() => ({ send: jest.fn() })),
+  GetParameterCommand: jest.fn((params) => params),
+  PutParameterCommand: jest.fn((params) => params),
+}))
+
+jest.unstable_mockModule('chalk', () => ({
+  default: mockChalk,
+}))
+
+jest.unstable_mockModule('ora', () => ({
+  default: mockOra,
+}))
+
+jest.unstable_mockModule('fs/promises', () => ({
+  readFile: jest.fn(),
+  writeFile: jest.fn(),
+}))
+
+// Import after mocking
+const { validateModelId, validateGenerationParams, validateConfig } = await import('../lib/config.js')
+
+describe('Model ID Validation', () => {
+  describe('validateModelId', () => {
+    test.each([
+      ['anthropic.claude-3-5-sonnet-20240620-v1:0', true],
+      ['anthropic.claude-3-haiku-20240307-v1:0', true],
+      ['anthropic.claude-instant-v1', true],
+      ['amazon.titan-text-express-v1', true],
+      ['amazon.titan-text-lite-v1', true],
+      ['amazon.nova-micro-v1:0', true],
+      ['amazon.nova-lite-v1:0', true],
+      ['meta.llama3-70b-instruct-v1:0', true],
+      ['meta.llama2-13b-chat-v1', true],
+      ['cohere.command-r-plus-v1:0', true],
+      ['cohere.command-text-v14', true],
+      ['cohere.embed-english-v3', true],
+      ['mistral.mistral-large-2402-v1:0', true],
+      ['mistral.mixtral-8x7b-instruct-v0:1', true],
+      ['ai21.jamba-1-5-large-v1:0', true],
+      ['ai21.j2-ultra-v1', true],
+      ['deepseek.deepseek-r1-v1:0', true],
+    ])('validates known model ID %s as valid', (modelId, isValid) => {
+      const result = validateModelId(modelId)
+      expect(result === null).toBe(isValid)
+    })
+
+    test.each([
+      ['unknown.model-v1', false],
+      ['invalid', false],
+      ['openai.gpt-4', false],
+      ['', false],
+      ['random-string', false],
+    ])('rejects unknown model ID %s', (modelId) => {
+      const result = validateModelId(modelId)
+      expect(result).not.toBeNull()
+      expect(typeof result).toBe('string')
+    })
+
+    test('returns error for null modelId', () => {
+      const result = validateModelId(null)
+      expect(result).not.toBeNull()
+      expect(result).toContain('non-empty string')
+    })
+
+    test('returns error for undefined modelId', () => {
+      const result = validateModelId(undefined)
+      expect(result).not.toBeNull()
+      expect(result).toContain('non-empty string')
+    })
+
+    test('returns error for non-string modelId', () => {
+      const result = validateModelId(123)
+      expect(result).not.toBeNull()
+      expect(result).toContain('non-empty string')
+    })
+  })
+})
+
+describe('Generation Parameter Validation', () => {
+  describe('validateGenerationParams', () => {
+    test('accepts valid parameters', () => {
+      const config = {
+        generation: {
+          maxTokens: 800,
+          temperature: 0.5,
+          topP: 0.9,
+        },
+      }
+      const errors = validateGenerationParams(config)
+      expect(errors).toHaveLength(0)
+    })
+
+    test('accepts temperature at boundaries', () => {
+      expect(validateGenerationParams({ generation: { temperature: 0 } })).toHaveLength(0)
+      expect(validateGenerationParams({ generation: { temperature: 1 } })).toHaveLength(0)
+    })
+
+    test('accepts topP at boundaries', () => {
+      expect(validateGenerationParams({ generation: { topP: 0 } })).toHaveLength(0)
+      expect(validateGenerationParams({ generation: { topP: 1 } })).toHaveLength(0)
+    })
+
+    test('rejects temperature > 1', () => {
+      const config = {
+        generation: {
+          maxTokens: 800,
+          temperature: 1.5,
+          topP: 0.9,
+        },
+      }
+      const errors = validateGenerationParams(config)
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors.some((err) => err.includes('temperature'))).toBe(true)
+    })
+
+    test('rejects temperature < 0', () => {
+      const config = {
+        generation: {
+          maxTokens: 800,
+          temperature: -0.1,
+          topP: 0.9,
+        },
+      }
+      const errors = validateGenerationParams(config)
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors.some((err) => err.includes('temperature'))).toBe(true)
+    })
+
+    test('rejects topP > 1', () => {
+      const config = {
+        generation: {
+          maxTokens: 800,
+          temperature: 0.5,
+          topP: 1.5,
+        },
+      }
+      const errors = validateGenerationParams(config)
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors.some((err) => err.includes('topP'))).toBe(true)
+    })
+
+    test('rejects topP < 0', () => {
+      const config = {
+        generation: {
+          maxTokens: 800,
+          temperature: 0.5,
+          topP: -0.1,
+        },
+      }
+      const errors = validateGenerationParams(config)
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors.some((err) => err.includes('topP'))).toBe(true)
+    })
+
+    test('rejects maxTokens < 1', () => {
+      const config = {
+        generation: {
+          maxTokens: 0,
+          temperature: 0.5,
+          topP: 0.9,
+        },
+      }
+      const errors = validateGenerationParams(config)
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors.some((err) => err.includes('maxTokens'))).toBe(true)
+    })
+
+    test('rejects negative maxTokens', () => {
+      const config = {
+        generation: {
+          maxTokens: -100,
+          temperature: 0.5,
+          topP: 0.9,
+        },
+      }
+      const errors = validateGenerationParams(config)
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors.some((err) => err.includes('maxTokens'))).toBe(true)
+    })
+
+    test('returns empty array for missing generation section', () => {
+      const config = {}
+      const errors = validateGenerationParams(config)
+      expect(errors).toHaveLength(0)
+    })
+
+    test('detects multiple validation errors', () => {
+      const config = {
+        generation: {
+          maxTokens: 0,
+          temperature: 2,
+          topP: -1,
+        },
+      }
+      const errors = validateGenerationParams(config)
+      expect(errors.length).toBe(3)
+    })
+  })
+})
+
+describe('Cross-model Configuration Validation', () => {
+  const createValidConfig = (modelId) => ({
+    model: { modelId },
+    knowledgeBase: { enabled: false, knowledgeBaseId: '' },
+    prompts: {
+      systemWithContext: 'test',
+      systemWithoutContext: 'test',
+      contextTemplate: 'test',
+    },
+    retrieval: { numberOfResults: 6, maxContextLength: 1000 },
+    generation: { maxTokens: 800, temperature: 0.5, topP: 0.9 },
+  })
+
+  test('validates configuration with Anthropic Claude model', () => {
+    const config = createValidConfig('anthropic.claude-3-5-sonnet-20240620-v1:0')
+    const errors = validateConfig(config)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('validates configuration with Amazon Titan model', () => {
+    const config = createValidConfig('amazon.titan-text-express-v1')
+    const errors = validateConfig(config)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('validates configuration with Amazon Nova model', () => {
+    const config = createValidConfig('amazon.nova-lite-v1:0')
+    const errors = validateConfig(config)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('validates configuration with Meta Llama model', () => {
+    const config = createValidConfig('meta.llama3-70b-instruct-v1:0')
+    const errors = validateConfig(config)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('validates configuration with Cohere model', () => {
+    const config = createValidConfig('cohere.command-r-plus-v1:0')
+    const errors = validateConfig(config)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('validates configuration with Mistral model', () => {
+    const config = createValidConfig('mistral.mistral-large-2402-v1:0')
+    const errors = validateConfig(config)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('validates configuration with AI21 model', () => {
+    const config = createValidConfig('ai21.jamba-1-5-large-v1:0')
+    const errors = validateConfig(config)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('validates configuration with DeepSeek model', () => {
+    const config = createValidConfig('deepseek.deepseek-r1-v1:0')
+    const errors = validateConfig(config)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('rejects configuration with unknown model provider', () => {
+    const config = createValidConfig('unknown.model-v1')
+    const errors = validateConfig(config)
+    expect(errors.length).toBeGreaterThan(0)
+    expect(errors.some((err) => err.includes('Unknown model provider'))).toBe(true)
+  })
+
+  test('reports both model and parameter errors', () => {
+    const config = {
+      model: { modelId: 'unknown.model-v1' },
+      knowledgeBase: { enabled: false, knowledgeBaseId: '' },
+      prompts: {
+        systemWithContext: 'test',
+        systemWithoutContext: 'test',
+        contextTemplate: 'test',
+      },
+      retrieval: { numberOfResults: 6, maxContextLength: 1000 },
+      generation: { maxTokens: 800, temperature: 1.5, topP: 0.9 },
+    }
+    const errors = validateConfig(config)
+    expect(errors.length).toBeGreaterThanOrEqual(2)
+    expect(errors.some((err) => err.includes('Unknown model provider'))).toBe(true)
+    expect(errors.some((err) => err.includes('temperature'))).toBe(true)
+  })
+})

--- a/tools/cli/lib/config.js
+++ b/tools/cli/lib/config.js
@@ -88,12 +88,71 @@ export async function updateConfig(configValue) {
 }
 
 /**
+ * Known model provider patterns for validation
+ */
+const MODEL_PATTERNS = {
+  anthropic: /^anthropic\.claude-/,
+  amazon: /^amazon\.(titan|nova)-/,
+  meta: /^meta\.llama/,
+  cohere: /^cohere\.(command|embed)-/,
+  mistral: /^mistral\./,
+  ai21: /^ai21\./,
+  deepseek: /^deepseek\./,
+}
+
+/**
+ * Validate model ID format
+ * @param {string} modelId - The model ID to validate
+ * @returns {string|null} Error message if invalid, null if valid
+ */
+export function validateModelId(modelId) {
+  if (!modelId || typeof modelId !== 'string') {
+    return 'modelId must be a non-empty string'
+  }
+
+  const isKnownProvider = Object.values(MODEL_PATTERNS).some((pattern) => pattern.test(modelId))
+  if (!isKnownProvider) {
+    return `Unknown model provider for modelId: ${modelId}. Expected patterns: anthropic.*, amazon.*, meta.*, cohere.*, mistral.*, ai21.*, deepseek.*`
+  }
+
+  return null
+}
+
+/**
+ * Validate generation parameters
+ * @param {Object} config - The configuration object
+ * @returns {string[]} Array of error messages
+ */
+export function validateGenerationParams(config) {
+  const errors = []
+
+  if (!config.generation) {
+    return errors // Will be caught by required field validation
+  }
+
+  const { temperature, topP, maxTokens } = config.generation
+
+  if (typeof temperature === 'number' && (temperature < 0 || temperature > 1)) {
+    errors.push('generation.temperature must be between 0 and 1')
+  }
+
+  if (typeof topP === 'number' && (topP < 0 || topP > 1)) {
+    errors.push('generation.topP must be between 0 and 1')
+  }
+
+  if (typeof maxTokens === 'number' && maxTokens < 1) {
+    errors.push('generation.maxTokens must be at least 1')
+  }
+
+  return errors
+}
+
+/**
  * Validate configuration JSON
  */
 export function validateConfig(config) {
   const requiredFields = [
     { path: 'model.modelId', type: 'string' },
-    { path: 'model.anthropicVersion', type: 'string' },
     { path: 'knowledgeBase.enabled', type: 'boolean' },
     { path: 'knowledgeBase.knowledgeBaseId', type: 'string' },
     { path: 'prompts.systemWithContext', type: 'string' },
@@ -104,11 +163,11 @@ export function validateConfig(config) {
     { path: 'generation.maxTokens', type: 'number' },
     { path: 'generation.temperature', type: 'number' },
     { path: 'generation.topP', type: 'number' },
-    { path: 'generation.topK', type: 'number' },
   ]
 
   const errors = []
 
+  // Validate required fields and types
   for (const field of requiredFields) {
     const value = getNestedValue(config, field.path)
     if (value === undefined) {
@@ -117,6 +176,19 @@ export function validateConfig(config) {
       errors.push(`Invalid type for ${field.path}: expected ${field.type}, got ${typeof value}`)
     }
   }
+
+  // Validate model ID format (only if modelId exists and is a string)
+  const modelId = getNestedValue(config, 'model.modelId')
+  if (modelId && typeof modelId === 'string') {
+    const modelError = validateModelId(modelId)
+    if (modelError) {
+      errors.push(modelError)
+    }
+  }
+
+  // Validate generation parameter ranges
+  const paramErrors = validateGenerationParams(config)
+  errors.push(...paramErrors)
 
   return errors
 }


### PR DESCRIPTION
## Summary

Refactors the chatbot to use AWS Bedrock's unified **Converse API** for model-agnostic inference, enabling support for any Bedrock model provider without code changes.

### Key Changes

- **Worker Lambda**: Replace `InvokeModelWithResponseStream` with `ConverseStreamCommand` for unified streaming across all model providers
- **Config Schema**: Remove Anthropic-specific fields (`anthropicVersion`, `topK`), add `modelSpecific` for provider-specific parameters
- **CLI Validation**: Add model ID pattern matching for known providers and parameter range validation
- **IAM Permissions**: Add `bedrock:Converse` and `bedrock:ConverseStream` permissions

### Supported Model Providers

| Provider | Example Model ID |
|----------|-----------------|
| Anthropic | `anthropic.claude-3-5-sonnet-20240620-v1:0` |
| Amazon | `amazon.titan-text-express-v1`, `amazon.nova-lite-v1:0` |
| Meta | `meta.llama3-70b-instruct-v1:0` |
| Cohere | `cohere.command-r-plus-v1:0` |
| Mistral | `mistral.mistral-large-2402-v1:0` |
| AI21 | `ai21.jamba-1-5-large-v1:0` |
| DeepSeek | `deepseek.deepseek-r1-v1:0` |

### Why Converse API?

The Converse API provides:
- Unified request/response format across all Bedrock models
- Internal handling of model-specific differences
- Streaming support via `ConverseStream`
- Simpler codebase without custom adapters per provider

## Test Plan

- [x] All 61 CLI tests pass (including 36 new model validation tests)
- [x] CDK synthesizes successfully
- [ ] Manual testing with Claude model
- [ ] Manual testing with Titan model (optional)
- [ ] Verify streaming works end-to-end

## Breaking Changes

Configuration schema changes require updating existing SSM parameters:
- Remove `model.anthropicVersion`
- Remove `generation.topK`
- Add `modelSpecific: {}` (optional)

Run `npm run cli config reset` to apply new defaults after deployment.